### PR TITLE
Add cache-busting path for webshims

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Since webshims does not support fingerprinting, this will result in 404s (missin
    (Note that this should be run directly, not in a dom-ready block.)
 
   ```javascript
-  $.webshims.setOptions('basePath', '/assets/webshims/shims/1.15.6/')
+  $.webshims.setOptions('basePath', '/webshims/shims/1.15.6/')
   $.webshims.polyfill()
   ```
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ Since webshims does not support fingerprinting, this will result in 404s (missin
     $(this).updatePolyfill()
   ```
 
+5. For Spork users, if you have a line to reload your routes for each spec run in your `spec_helper`:
+
+  ```ruby
+  Spork.each_run do
+    # This code will be run each time you run your specs.
+    load "#{Rails.root}/config/routes.rb"
+  end
+  ```
+
+   Then you need to add the `mount` to your `config/routes.rb` otherwise it gets removed by Spork's reload.
+
+   ```ruby
+   mount Webshims::Rails::Rewrite.new, at: '/webshims/shims'
+   ```
+
 ## Updating this gem
 
 This is only in the case this repository is not up-to-date; I try to stay current with webshims but sometimes I miss the webshims releases.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Since webshims does not support fingerprinting, this will result in 404s (missin
    (Note that this should be run directly, not in a dom-ready block.)
 
   ```javascript
-  $.webshims.setOptions('basePath', '/assets/webshims/shims/')
+  $.webshims.setOptions('basePath', '/assets/webshims/shims/1.15.6/')
   $.webshims.polyfill()
   ```
+
+   The version number above should match the version of Webshims. When you update the gem make sure to change this so browser-cached files will be reloaded. If you are interpolating your JavaScript, you can use the helper `webshims_path` to automatically populate the version number.
 
 4. For Turbolinks users only: you'll need to update the polyfill on page load:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Since webshims does not support fingerprinting, this will result in 404s (missin
   $.webshims.polyfill()
   ```
 
-   The version number above should match the version of Webshims. When you update the gem make sure to change this so browser-cached files will be reloaded. If you are interpolating your JavaScript, you can use the helper `webshims_path` to automatically populate the version number.
+   The version number above should match the version of Webshims. When you update the gem change this so browser-cached files get reloaded. If you are interpolating your JavaScript, you can use the helper `webshims_path` to automatically populate the path with version number.
 
 4. For Turbolinks users only: you'll need to update the polyfill on page load:
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   if ::Rails::VERSION::MAJOR < 4
-    mount Webshims::Rails::Rewrite, :at => "/assets/webshims/shims"
+    mount Webshims::Rails::Rewrite.new, :at => "/assets/webshims/shims"
   else
-    mount Webshims::Rails::Rewrite, :at => "/webshims/shims"
+    mount Webshims::Rails::Rewrite.new, :at => "/webshims/shims"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,7 @@
+Rails.application.routes.draw do
+  if ::Rails::VERSION::MAJOR < 4
+    mount Webshims::Rails::Rewrite, :at => "/assets/webshims/shims"
+  else
+    mount Webshims::Rails::Rewrite, :at => "/webshims/shims"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,3 @@
 Rails.application.routes.draw do
-  if ::Rails::VERSION::MAJOR < 4
-    mount Webshims::Rails::Rewrite.new, :at => "/assets/webshims/shims"
-  else
-    mount Webshims::Rails::Rewrite.new, :at => "/webshims/shims"
-  end
+  mount Webshims::Rails::Rewrite.new, :at => "/webshims/shims"
 end

--- a/lib/webshims-rails.rb
+++ b/lib/webshims-rails.rb
@@ -1,4 +1,6 @@
 require "webshims-rails/version"
+require "webshims-rails/view-helpers"
+require "webshims-rails/rewrite"
 
 module Webshims
   module Rails
@@ -11,6 +13,10 @@ module Webshims
         initializer :append_webshims_assets_path, :group => :all do |app|
           app.config.assets.precompile << /webshims/
         end
+      end
+
+      initializer "Webshims::Rails::ViewHelpers" do
+        ActiveSupport.on_load(:action_view) { include Webshims::Rails::ViewHelpers }
       end
     end
   end

--- a/lib/webshims-rails/rewrite.rb
+++ b/lib/webshims-rails/rewrite.rb
@@ -3,14 +3,18 @@ module Webshims
     class Rewrite < Rack::File
 
       def initialize
-        env[PATH_INFO] = env[PATH_INFO].gsub(%r(\A/[0-9.]+/), '')
         super(root)
+      end
+
+      def call(env)
+        env["PATH_INFO"] = env["PATH_INFO"].gsub(%r(\A/[0-9.]+/), '')
+        super(env)
       end
 
       private
 
       def root
-        File.join(Gem.loaded_specs['webshims-rails'].full_gem_path, "vendor", "assets", "javascripts", "webshims", "shims")
+        File.join(Gem.loaded_specs["webshims-rails"].full_gem_path, "vendor", "assets", "javascripts", "webshims", "shims")
       end
     end
   end

--- a/lib/webshims-rails/rewrite.rb
+++ b/lib/webshims-rails/rewrite.rb
@@ -1,36 +1,16 @@
 module Webshims
   module Rails
-    class Rewrite
-      class << self
-        def call(env)
-          filename = path(env)
-          body = File.read(filename)
-          [
-              200,
-              {
-                  "Content-Type" => content_type(filename),
-                  "Content-Length" => bytesize(body)
-              },
-              [body]
-          ]
-        end
+    class Rewrite < Rack::File
 
-        private
+      def initialize
+        env[PATH_INFO] = env[PATH_INFO].gsub(%r(\A/[0-9.]+/), '')
+        super(root)
+      end
 
-        def path(env)
-          filename = env["PATH_INFO"].gsub(%r(\A/[0-9.]+/), '')
-          File.join(Gem.loaded_specs['webshims-rails'].full_gem_path, "vendor", "assets", "javascripts", "webshims", "shims", filename)
-        end
+      private
 
-        def content_type(filename)
-          extname = File.extname(filename)[1..-1]
-          mime_type = Mime::Type.lookup_by_extension(extname)
-          mime_type.to_s
-        end
-
-        def bytesize(content)
-          "".respond_to?(:bytesize) ? content.bytesize.to_s : content.size.to_s
-        end
+      def root
+        File.join(Gem.loaded_specs['webshims-rails'].full_gem_path, "vendor", "assets", "javascripts", "webshims", "shims")
       end
     end
   end

--- a/lib/webshims-rails/rewrite.rb
+++ b/lib/webshims-rails/rewrite.rb
@@ -1,0 +1,37 @@
+module Webshims
+  module Rails
+    class Rewrite
+      class << self
+        def call(env)
+          filename = path(env)
+          body = File.read(filename)
+          [
+              200,
+              {
+                  "Content-Type" => content_type(filename),
+                  "Content-Length" => bytesize(body)
+              },
+              [body]
+          ]
+        end
+
+        private
+
+        def path(env)
+          filename = env["PATH_INFO"].gsub(%r(\A/[0-9.]+/), '')
+          File.join(Gem.loaded_specs['webshims-rails'].full_gem_path, "vendor", "assets", "javascripts", "webshims", "shims", filename)
+        end
+
+        def content_type(filename)
+          extname = File.extname(filename)[1..-1]
+          mime_type = Mime::Type.lookup_by_extension(extname)
+          mime_type.to_s
+        end
+
+        def bytesize(content)
+          "".respond_to?(:bytesize) ? content.bytesize.to_s : content.size.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/webshims-rails/view-helpers.rb
+++ b/lib/webshims-rails/view-helpers.rb
@@ -1,0 +1,11 @@
+module Webshims
+  module Rails
+    module ViewHelpers
+      def webshims_path
+        path = "/webshims/shims/#{Webshims::Rails::WEBSHIMS_VERSION}/"
+        path = "/assets/#{path}" if ::Rails::VERSION::MAJOR < 4
+        path
+      end
+    end
+  end
+end

--- a/lib/webshims-rails/view-helpers.rb
+++ b/lib/webshims-rails/view-helpers.rb
@@ -2,9 +2,7 @@ module Webshims
   module Rails
     module ViewHelpers
       def webshims_path
-        path = "/webshims/shims/#{Webshims::Rails::WEBSHIMS_VERSION}/"
-        path = "/assets/#{path}" if ::Rails::VERSION::MAJOR < 4
-        path
+        "/webshims/shims/#{Webshims::Rails::WEBSHIMS_VERSION}/"
       end
     end
   end


### PR DESCRIPTION
Change the path for Webshims from `/assets/webshims/shims/` to `/assets/webshims/shims/1.15.6` so that when Webshims is updated, cached versions of the combos files will not be used by the browser causing incompatibilities. See #21.

There are no tests in this code because you didn't have any tests in the original code so I wasn't sure what test harness you prefer. I'm happy to add the scaffolded rails app and use rspec to cover this.

Also, the Rails 4 changes are entirely speculative as I'm not using this in a Rails 4 environment to test.

I'd appreciate any feedback on this and suggestions for improvement.