### PR TITLE
automatically create nondigest non versioned files on asset precompile

### DIFF
--- a/lib/tasks/webshims.rake
+++ b/lib/tasks/webshims.rake
@@ -1,13 +1,22 @@
 require 'fileutils'
 
-desc "Copy the webshims to public/webshims so dynamic features will work."
-task "webshims:update_public" do
-  shim_root = Webshims::Rails::Engine.root.join('lib', 'assets', 'javascripts', 'webshims')
-  FileUtils.cp_r(shim_root, Rails.root.join('public'))
+desc 'Add a nondigest copy of assets so dynamic features will work.'
+task 'webshims:update_public' do
+  fingerprint = /\-[0-9a-f]{32,64}\./
+  path        = File.join Rails.root.to_s, 'public', 'assets', 'webshims', '**/*'
+  files       = Dir[path]
 
-  puts "Updated webshims files in /public/webshims"
+  files.each do |file|
+    next unless file =~ fingerprint
+    nondigest = file.sub fingerprint, '.'
+
+    if !File.exist?(nondigest) || File.mtime(file) > File.mtime(nondigest)
+      FileUtils.cp file, nondigest, verbose: true, preserve: true
+    end
+  end
+
+  puts 'Added nondigest files in /public/assets/webshims'
 end
-
 
 desc "Copy the webshims to public/webshims/[version] for cache-busting."
 task "webshims:update_public_versioned" do
@@ -20,4 +29,10 @@ task "webshims:update_public_versioned" do
   puts "\nBe sure your webshims options are set as follows:"
   puts %Q{    $.webshims.setOptions('basePath', '/webshims/#{Webshims::Rails::WEBSHIMS_VERSION}/shims/')}
   puts "\nYou can use ERB to dynamically set this path; See README for more information."
+end
+
+if Rake::Task.task_defined?('assets:precompile')
+  Rake::Task['assets:precompile'].enhance do
+    Rake::Task['webshims:update_public'].invoke if defined?(Webshims)
+  end
 end


### PR DESCRIPTION
The way non digest assets are created changed a little bit from always
copying the whole to only copying changed files on each run.  With this,
the task can automatically be invoked on each precompile run and only
copies something if needed.

The only Rails config change to make this gem work now is to add a
`Rails.application.config.assets.precompile += %w( webshims/* )` to an
initializer.

IMO this simplifies installation and updating process a lot (even though only in the non versioned directoy case).

If this PR could be accepted, I can update the readme accordingly, too.